### PR TITLE
users/register のテスト追加

### DIFF
--- a/test/controller/users/register.test.js
+++ b/test/controller/users/register.test.js
@@ -1,11 +1,15 @@
 'use strict';
 const requestHelper = require('../helper/requestHelper');
-const MAIL_REGEX = /^([a-za-z0-9])+([a-zA-Z0-9\\._-])*@([a-zA-Z0-9\\._-]+)*$/;
 
 jest.mock('../../../app/repository/provider');
 jest.mock('../../../app/controller/server');
 
-test('correct params return 200', async () => {
+/**
+* /usrs/register に対してのPOST送信の正常系.
+* payload: requestBodyにエラーがなく、
+* 後続の処理にエラーがない場合.
+*/
+test('requestBodyに必要なデータが揃っていて正常にrequestとresponseが行われる', async () => {
   const payload = {
     id: '0000002',
     user: {
@@ -19,23 +23,11 @@ test('correct params return 200', async () => {
 
     expect(response.statusCode).toBe(200);
     expect(payload.id).toEqual(expect.stringMatching(/^[0-9]+$/));
-    expect(payload.user.mail).toEqual(expect.stringMatching(MAIL_REGEX));
     expect(typeof payload.user.name).toBe('string');
   });
 });
 
-test('parameter-name is brunk return 400', async () => {
-  const payload = {
-    id: '0000002',
-    user: {
-      mail: 'john.doe@test.jp',
-    },
-  };
-
-  await requestHelper.post('/register', payload, response => expect(response.statusCode).toBe(400));
-});
-
-test('parameter-id is brunk return 400', async () => {
+test('idがrequestBodyにない場合、400エラーになる', async () => {
   const payload = {
     user: {
       mail: 'john.doe@test.jp',
@@ -46,7 +38,18 @@ test('parameter-id is brunk return 400', async () => {
   await requestHelper.post('/register', payload, response => expect(response.statusCode).toBe(400));
 });
 
-test('parameter-mail is brunk return 400', async () => {
+test('user.nameがrequestBodyにない場合、400エラーになる', async () => {
+  const payload = {
+    id: '0000002',
+    user: {
+      mail: 'john.doe@test.jp',
+    },
+  };
+
+  await requestHelper.post('/register', payload, response => expect(response.statusCode).toBe(400));
+});
+
+test('user.mailがrequestBodyにない場合、400エラーになる', async () => {
   const payload = {
     id: '0000002',
     user: {
@@ -57,7 +60,7 @@ test('parameter-mail is brunk return 400', async () => {
   await requestHelper.post('/register', payload, response => expect(response.statusCode).toBe(400));
 });
 
-test('parameter-mail is invalid pattern return 400', async () => {
+test('user.mailがアドレス形式出ない文字列にない場合、400エラーになる', async () => {
   const payload = {
     id: '0000002',
     user: {
@@ -68,3 +71,17 @@ test('parameter-mail is invalid pattern return 400', async () => {
 
   await requestHelper.post('/register', payload, response => expect(response.statusCode).toBe(400));
 });
+
+
+test('user.mailのアドレス形式でも先頭に大文字を使っている場合、400エラーになる', async () => {
+  const payload = {
+    id: '0000002',
+    user: {
+      mail: 'John.doe@test.jp',
+      name: 'John Doe',
+    },
+  };
+
+  await requestHelper.post('/register', payload, response => expect(response.statusCode).toBe(400));
+});
+


### PR DESCRIPTION
## 概要
- テストケースを日本語に変更

## 悩みどころ
- メールアドレスのパターン
  - メールアドレスの形式をどこまで精密に管理するか
  - 一旦は、先頭の大文字NG・@つなぎくらい
  - これ以上精緻に判断する必要がなければ変更せずにいきます