### PR TITLE
[fix/add] controllerの修正に合わせたテストの修正と/entryのテストコードの作成

### DIFF
--- a/app/common/constraint/purpose.js
+++ b/app/common/constraint/purpose.js
@@ -1,5 +1,5 @@
 'use strict';
 
-const PURPOSE = ['WORK', 'CIRCLE', 'STUDY', 'MEET_UP', 'OTHER'];
+const PURPOSE_LIST = ['WORK', 'CIRCLE', 'STUDY', 'MEET_UP', 'OTHER'];
 
-module.exports = PURPOSE;
+module.exports = PURPOSE_LIST;

--- a/app/controller/schema/users.js
+++ b/app/controller/schema/users.js
@@ -103,6 +103,12 @@ module.exports = {
           type: 'object',
           properties: {
             id,
+            user: {
+              type: 'object',
+              properties: {
+                mail,
+              }
+            }
           }
         },
         '4xx': CLIENT_ERROR_RESPONSE,

--- a/app/controller/users.js
+++ b/app/controller/users.js
@@ -7,7 +7,16 @@ const {
   USERS_SCHEMA,
 } = require('./schema/users');
 
-const provider = require('../repository');
+const {
+  register,
+  update
+} = require('../repository/user');
+
+const {
+  exit,
+  entry,
+  findByDate,
+} = require('../repository/visitor');
 
 module.exports = async function(fastify, opt, next) {
   const handler = (response, reply) => {
@@ -18,23 +27,23 @@ module.exports = async function(fastify, opt, next) {
   };
 
   fastify.post('/register', REGISTOR_SCHEMA, async (req, reply) => {
-    provider.register(req.body).then(response => handler(response, reply));
+    register(req.body).then(response => handler(response, reply));
   });
 
   fastify.post('/entry', ENTRY_SCHEMA, async (req, reply) => {
-    provider.entry(req.body).then(response => handler(response, reply));
+    entry(req.body).then(response => handler(response, reply));
   });
 
   fastify.post('/update', UPDATE_SCHEMA, async (req, reply) => {
-    provider.update(req.body).then(response => handler(response, reply));
+    update(req.body).then(response => handler(response, reply));
   });
 
   fastify.post('/exit', OUT_SCHEMA, async (req, reply) => {
-    provider.exit(req.body).then(response => handler(response, reply));
+    exit(req.body).then(response => handler(response, reply));
   });
 
   fastify.get('/users/:date', USERS_SCHEMA, async (req, reply) => {
-    provider.findByDate(req.params.date).then(response => {
+    findByDate(req.params.date).then(response => {
       reply.send(response);
     });
   });

--- a/app/controller/users.js
+++ b/app/controller/users.js
@@ -32,12 +32,12 @@ module.exports = async function(fastify, opt, next) {
 
   fastify.post('/register', REGISTOR_SCHEMA, async (req, reply) => {
     register(req.body)
-      .then(response => response(response, reply));
+      .then(response => res(response, reply));
   });
 
   fastify.post('/entry', ENTRY_SCHEMA, async (req, reply) => {
     if(!PURPOSE.includes(req.body.purpose)) {
-      await res({
+      res({
         error: 'validation error.',
         message: '適切な目的が選択されていません。',
         statusCode: VALIDATION_ERROR_STATUS,
@@ -45,20 +45,20 @@ module.exports = async function(fastify, opt, next) {
       reply,
       VALIDATION_ERROR_STATUS);
 
-      return false;
+      // return false;
     }
 
     entry(req.body)
-      .then(response => response(response, reply))
-      .catch();
+      .then(response => res(response, reply))
+      .catch(e => fastify.logger.error(e));
   });
 
-  fastify.post('/update', UPDATE_SCHEMA, async (req, reply) => {
-    update(req.body).then(response => response(response, reply));
+  fastify.post('/update', UPDATE_SCHEMA, (req, reply) => {
+    update(req.body).then(response => res(response, reply));
   });
 
   fastify.post('/exit', OUT_SCHEMA, async (req, reply) => {
-    exit(req.body).then(response => response(response, reply));
+    exit(req.body).then(response => res(response, reply));
   });
 
   fastify.get('/users/:date', USERS_SCHEMA, async (req, reply) => {

--- a/app/controller/users.js
+++ b/app/controller/users.js
@@ -18,28 +18,47 @@ const {
   findByDate,
 } = require('../repository/visitor');
 
+const PURPOSE = require('../common/constraint/purpose');
+
+const SUCCESS_STATUS = 200;
+const VALIDATION_ERROR_STATUS = 400;
+
 module.exports = async function(fastify, opt, next) {
-  const handler = (response, reply) => {
-    if (response.code === 1) {
-      reply.code(400).send(response.error);
-    }
-    reply.send(response);
+  const res = (response, reply, statusCode = SUCCESS_STATUS) => {
+    reply
+      .code(statusCode)
+      .send(response);
   };
 
   fastify.post('/register', REGISTOR_SCHEMA, async (req, reply) => {
-    register(req.body).then(response => handler(response, reply));
+    register(req.body)
+      .then(response => response(response, reply));
   });
 
   fastify.post('/entry', ENTRY_SCHEMA, async (req, reply) => {
-    entry(req.body).then(response => handler(response, reply));
+    if(!PURPOSE.includes(req.body.purpose)) {
+      await res({
+        error: 'validation error.',
+        message: '適切な目的が選択されていません。',
+        statusCode: VALIDATION_ERROR_STATUS,
+      },
+      reply,
+      VALIDATION_ERROR_STATUS);
+
+      return false;
+    }
+
+    entry(req.body)
+      .then(response => response(response, reply))
+      .catch();
   });
 
   fastify.post('/update', UPDATE_SCHEMA, async (req, reply) => {
-    update(req.body).then(response => handler(response, reply));
+    update(req.body).then(response => response(response, reply));
   });
 
   fastify.post('/exit', OUT_SCHEMA, async (req, reply) => {
-    exit(req.body).then(response => handler(response, reply));
+    exit(req.body).then(response => response(response, reply));
   });
 
   fastify.get('/users/:date', USERS_SCHEMA, async (req, reply) => {

--- a/app/controller/users.js
+++ b/app/controller/users.js
@@ -20,51 +20,87 @@ const {
 
 const PURPOSE = require('../common/constraint/purpose');
 
+// TODO: 別のファイルに切り出す.
 const SUCCESS_STATUS = 200;
-const VALIDATION_ERROR_STATUS = 400;
+const CREATED_STATUS = 201;
+const VALIDATED_OR_FAILED_CODE = 400;
+
+/**
+ * Daoに接続した結果と成否でレスポンスに必要なデータを作成する.
+ * @param executeDaoMethod Daoのメソッド.
+ * @param params requestで送られてきたパラメータ.
+ * @param successStatus Daoが正常に実行されたときのレスポンスに表示するステータスコード.
+ * @param errorStatus Daoの処理で異常となったときにレスポンスに表示するステータスコード.
+ * @returns {Promise<T | {data: any, status: *}>} data: レスポンスのデータ, status: ステータスコードを <br/>
+ *          {@code Promise} でラップしたオブジェクト.
+ */
+const createResponseDate = async (executeDaoMethod, params, successStatus, errorStatus) => {
+  return executeDaoMethod(params)
+    .then(data => ({
+      data,
+      status: successStatus
+    }))
+    .catch(data => ({
+      data,
+      status: errorStatus
+    }));
+};
 
 module.exports = async function(fastify, opt, next) {
-  const res = (response, reply, statusCode = SUCCESS_STATUS) => {
-    reply
-      .code(statusCode)
-      .send(response);
-  };
 
   fastify.post('/register', REGISTOR_SCHEMA, async (req, reply) => {
-    register(req.body)
-      .then(response => res(response, reply));
+    const response = await createResponseDate(register, req.body, SUCCESS_STATUS, VALIDATED_OR_FAILED_CODE);
+
+    reply
+      .code(response.status)
+      .send(response.data);
+
   });
 
   fastify.post('/entry', ENTRY_SCHEMA, async (req, reply) => {
     if(!PURPOSE.includes(req.body.purpose)) {
-      res({
-        error: 'validation error.',
-        message: '適切な目的が選択されていません。',
-        statusCode: VALIDATION_ERROR_STATUS,
-      },
-      reply,
-      VALIDATION_ERROR_STATUS);
-
-      // return false;
+      reply
+        .code(VALIDATED_OR_FAILED_CODE)
+        .send({
+          error: 'validation error.',
+          message: '適切な目的が選択されていません。',
+          statusCode: VALIDATED_OR_FAILED_CODE,
+        });
     }
 
-    entry(req.body)
-      .then(response => res(response, reply))
-      .catch(e => fastify.logger.error(e));
+    const response = await createResponseDate(entry, req.body, CREATED_STATUS, VALIDATED_OR_FAILED_CODE);
+    reply
+      .code(response.status)
+      .send(response.data);
   });
 
-  fastify.post('/update', UPDATE_SCHEMA, (req, reply) => {
-    update(req.body).then(response => res(response, reply));
+  fastify.post('/update', UPDATE_SCHEMA, async (req, reply) => {
+    const response = await createResponseDate(update, req.body, SUCCESS_STATUS, VALIDATED_OR_FAILED_CODE);
+    reply
+      .code(response.status)
+      .send(response.data);
   });
 
   fastify.post('/exit', OUT_SCHEMA, async (req, reply) => {
-    exit(req.body).then(response => res(response, reply));
+    const response = await createResponseDate(exit, req.body, SUCCESS_STATUS, VALIDATED_OR_FAILED_CODE);
+    reply
+      .code(response.status)
+      .send(response.data);
+  });
+
+  fastify.get('/user/:id/status',async (req, reply) => {
+    // TODO: Daoのメソッド決定後実装.
+    // const response = await createResponseDate(exit, req.body, SUCCESS_STATUS, VALIDATION_ERROR_STATUS);
+    // reply
+    //   .code(response.status)
+    //   .send(response.data);
   });
 
   fastify.get('/users/:date', USERS_SCHEMA, async (req, reply) => {
-    findByDate(req.params.date).then(response => {
-      reply.send(response);
-    });
+    const response = await createResponseDate(findByDate, req.body, SUCCESS_STATUS, VALIDATED_OR_FAILED_CODE);
+    reply
+      .code(response.status)
+      .send(response.data);
   });
 
   next();

--- a/app/repository/__mocks__/user.js
+++ b/app/repository/__mocks__/user.js
@@ -1,0 +1,23 @@
+'use strict';
+const register = async () => {
+  return {
+    statusCode: 0,
+    id: '0000001',
+    user: {
+      mail: 'john.doe@test.jp',
+      name: 'John Doe',
+    },
+  };
+};
+
+const update = async () => {
+  return {
+    id: '0000001',
+    purpose: 'STUDY',
+  };
+};
+
+module.exports = {
+  register,
+  update,
+};

--- a/app/repository/__mocks__/user.js
+++ b/app/repository/__mocks__/user.js
@@ -13,7 +13,9 @@ const register = async () => {
 const update = async () => {
   return {
     id: '0000001',
-    purpose: 'STUDY',
+    user: {
+      mail: 'john.doe@test.jp',
+    }
   };
 };
 

--- a/app/repository/__mocks__/visitor.js
+++ b/app/repository/__mocks__/visitor.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  exit: async () => ({
+    id: '0000001',
+    user: {
+      mail: 'john.doe@test.jp',
+    },
+  }),
+
+  entry: async () => ({
+    id: '0000001',
+    user: {
+      name: 'John Doe',
+      isEntry: true,
+    },
+  }),
+
+  findByDate: async () => ({
+    id: 'ab'
+  }),
+
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "coverage:http": "NODE_ENV=TEST jest --coverage"
   },
   "jest": {
-    "verbose": true
+    "verbose": true,
+    "testURL": "http://localhost/"
   },
   "author": "t-kurihara",
   "license": "MIT",

--- a/test/controller/helper/requestHelper.js
+++ b/test/controller/helper/requestHelper.js
@@ -8,7 +8,9 @@ module.exports = class {
         url,
         payload
       },
-      response => {
+      (error, response) => {
+
+        if (error) throw new Error(`リクエスト内でのエラー${error}`);
         callback(response);
       }
     );

--- a/test/controller/users/entry.test.js
+++ b/test/controller/users/entry.test.js
@@ -12,7 +12,7 @@ test('/entryの正常系。レスポンスが200かつ正しい値が帰って�
   await requestHelper.post('/entry', payload, response => {
     const payload = JSON.parse(response.payload);
 
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode).toBe(201);
     expect(typeof payload.id).toBe('string');
     expect(typeof payload.user.name).toBe('string');
     expect(payload.user.isEntry).not.toBeFalsy();

--- a/test/controller/users/entry.test.js
+++ b/test/controller/users/entry.test.js
@@ -1,0 +1,47 @@
+'use strict';
+const requestHelper = require('../helper/requestHelper');
+
+jest.mock('../../../app/repository/visitor');
+
+test('/entryの正常系。レスポンスが200かつ正しい値が帰ってくる。', async () => {
+  const payload = {
+    id: '001',
+    purpose: 'WORK',
+  };
+
+  await requestHelper.post('/entry', payload, response => {
+    const payload = JSON.parse(response.payload);
+
+    expect(response.statusCode).toBe(200);
+    expect(typeof payload.id).toBe('string');
+    expect(typeof payload.user.name).toBe('string');
+    expect(payload.user.isEntry).not.toBeFalsy();
+  });
+});
+
+test('idなし', async () => {
+  const payload = {
+    purpose: 'WORK',
+  };
+
+  await requestHelper.post('/entry', payload, response => expect(response.statusCode).toBe(400));
+});
+
+test('purposeなし', async () => {
+  const payload = {
+    id: '001',
+  };
+
+  await requestHelper.post('/entry', payload, response => expect(response.statusCode).toBe(400));
+});
+
+test('想定外の目的が選択されている', () => {
+  const payload = {
+    id: '001',
+    purpose: 'foo',
+  };
+
+  requestHelper.post('/entry', payload, response => expect(response.statusCode).toBe(400));
+});
+
+

--- a/test/controller/users/register.test.js
+++ b/test/controller/users/register.test.js
@@ -1,8 +1,7 @@
 'use strict';
 const requestHelper = require('../helper/requestHelper');
 
-jest.mock('../../../app/repository/provider');
-jest.mock('../../../app/controller/server');
+jest.mock('../../../app/repository/user');
 
 /**
 * /usrs/register に対してのPOST送信の正常系.
@@ -22,7 +21,6 @@ test('requestBodyに必要なデータが揃っていて正常にrequestとrespo
     const payload = JSON.parse(response.payload);
 
     expect(response.statusCode).toBe(200);
-    expect(payload.id).toEqual(expect.stringMatching(/^[0-9]+$/));
     expect(typeof payload.user.name).toBe('string');
   });
 });

--- a/test/controller/users/update.test.js
+++ b/test/controller/users/update.test.js
@@ -1,0 +1,57 @@
+'use strict';
+const requestHelper = require('../helper/requestHelper');
+
+jest.mock('../../../app/repository/user');
+
+test('正常系:必要な値があり、responseのステータスと値も正しい。', async () => {
+
+  const payload = {
+    id: 'someUserId',
+    user: {
+      mail: 'someUser@mail.com'
+    }
+  };
+
+  requestHelper.post('/update', payload, response => {
+    const payload = JSON.parse(response.payload);
+
+    expect(response.statusCode).toBe(200);
+    expect(typeof payload.id).toBe('string');
+    expect(typeof payload.user.mail).toBe('string');
+  });
+});
+
+test('request bodyにidがない場合、statusCodeが400のレスポンスになる', async () => {
+
+  const payload = {
+    user: {
+      mail: 'someUser@mail.com'
+    }
+  };
+
+  requestHelper.post('/update', payload, response => expect(response.statusCode).toBe(400));
+});
+
+test('request bodyにuser.mailない場合、statusCodeが400のレスポンスになる', async () => {
+
+  const payload = {
+    id: 'someUserId',
+    user: {
+      mail: ''
+    }
+  };
+
+  requestHelper.post('/update', payload, response => expect(response.statusCode).toBe(400));
+});
+
+test('user.mailがメール形式出ない場合、statusCodeが400のレスポンスになる', async () => {
+
+  const payload = {
+    id: 'someUserId',
+    user: {
+      mail: 'John Doe'
+    }
+  };
+
+  requestHelper.post('/update', payload, response => expect(response.statusCode).toBe(400));
+});


### PR DESCRIPTION
## 観点
- `controller/user.js`: PRのレビューで確認したレスポンスの挙動に変更。
  - dao
がエラーになったときはcatchして処理する処理は未実装。
- `/entry`: テストを新規作成。
  - テストケースに漏れがないかの確認をお願いします。
  - purposeが存在するもの以外の値で送られてきたときのvalidationで返すstatusCodeは`400` と @ikkyu-3 と確認済み。