### PR TITLE
[add/fix] /exit のテストケースを作成.APIドキュメントを修正.

### DIFF
--- a/app/repository/__mocks__/user.js
+++ b/app/repository/__mocks__/user.js
@@ -1,7 +1,6 @@
 'use strict';
 const register = async () => {
   return {
-    statusCode: 0,
     id: '0000001',
     user: {
       mail: 'john.doe@test.jp',

--- a/app/repository/__mocks__/visitor.js
+++ b/app/repository/__mocks__/visitor.js
@@ -4,10 +4,10 @@ module.exports = {
   exit: async () => ({
     id: '0000001',
     user: {
-      mail: 'john.doe@test.jp',
+      name: 'john.doe',
+      isEntry: false,
     },
   }),
-
   entry: async () => ({
     id: '0000001',
     user: {
@@ -15,9 +15,7 @@ module.exports = {
       isEntry: true,
     },
   }),
-
   findByDate: async () => ({
     id: 'ab'
   }),
-
 };

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -188,11 +188,8 @@ paths:
             type: object
             required:
               - id
-              - purpose
             properties:
               id:
-                type: string
-              purpose:
                 type: string
       tags:
         - User

--- a/test/controller/users/exit.test.js
+++ b/test/controller/users/exit.test.js
@@ -1,0 +1,26 @@
+'use strict';
+const requestHelper = require('../helper/requestHelper');
+
+jest.mock('../../../app/repository/visitor');
+
+test('/exitの正常系。レスポンスが200かつ正しい値が帰ってくる。', async () => {
+  const payload = {
+    id: '001',
+  };
+
+  await requestHelper.post('/exit', payload, response => {
+    const payload = JSON.parse(response.payload);
+
+    expect(response.statusCode).toBe(200);
+    expect(typeof payload.id).toBe('string');
+    expect(typeof payload.user.name).toBe('string');
+    expect(payload.user.isEntry).toBeFalsy();
+  });
+});
+
+test('request bodyにidがない場合、statusCodeが400のレスポンスになる', async () => {
+  const payload = {};
+
+  await requestHelper.post('/exit', payload, response => expect(response.statusCode).toBe(400));
+});
+


### PR DESCRIPTION
## 観点
- `/exit` のswaggerのドキュメントがwikiと異なっていたので修正。
- `/exit` のテストケースを作成。