### PR TITLE
cross origin 制約を外す

### DIFF
--- a/app/controller/server.js
+++ b/app/controller/server.js
@@ -25,6 +25,9 @@ const getOpt = () => {
 
 const buildServer = async () => {
   const fastify = (await require('fastify'))(getOpt());
+  fastify.register(require('fastify-cors'), {
+    origin: true
+  });
 
   fastify.register(require('fastify-swagger'), {
     routePrefix: '/documentation',

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "elasticsearch": "^14.1.0",
     "fastify": "^1.7.0",
+    "fastify-cors": "^0.1.0",
     "fastify-swagger": "^0.14.0",
     "moment": "^2.20.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,6 +1142,13 @@ fast-safe-stringify@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz#9fe22c37fb2f7f86f06b8f004377dbf8f1ee7bc1"
 
+fastify-cors@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fastify-cors/-/fastify-cors-0.1.0.tgz#58b04b056eb42a3d4ef7f916f376016ca9088c7f"
+  dependencies:
+    fastify-plugin "^1.2.0"
+    vary "^1.1.2"
+
 fastify-plugin@^1.0.0, fastify-plugin@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-1.2.0.tgz#b87274ad9d14e41efcd3240c64f5dee4c39b2154"
@@ -3668,6 +3675,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
+
+vary@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
[fastify-cors](https://github.com/fastify/fastify-cors) でoriginをまたいだAjaxを可能にする。